### PR TITLE
ADD: RemoveLineBreaks function

### DIFF
--- a/regex/rstring/string.go
+++ b/regex/rstring/string.go
@@ -48,3 +48,12 @@ func ContainsSpecialChars(s string) bool {
 
 	return !isStringAlphabetic(s)
 }
+
+// RemoveLineBreaks removes all line breaks from a string using a regex.
+// As per https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#lineending,
+// Any Unicode linebreak sequence, is equivalent to \u000D\u000A|[\u000A\u000B\u000C\u000D\u0085\u2028\u2029] .
+func RemoveLineBreaks(s string) string {
+	re := regexp.MustCompile(`\x{000D}\x{000A}|[\x{000A}\x{000B}\x{000C}\x{000D}\x{0085}\x{2028}\x{2029}]`)
+
+	return re.ReplaceAllString(s, ``)
+}

--- a/regex/rstring/string_test.go
+++ b/regex/rstring/string_test.go
@@ -102,3 +102,15 @@ func TestContainsSpecialChars(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveLineBreaks(t *testing.T) {
+	input := "One\r,\r\ntwo\u0085 three\u2028!\u2029'"
+	result := "One,two three!'"
+	output := rstring.RemoveLineBreaks(input)
+	diff := reflect.DeepEqual(result, output)
+
+	if !diff {
+		t.Errorf("RemoveLineBreaks(%s) Failed: expected %s, actual %s",
+			input, result, output)
+	}
+}

--- a/regex/rstring/string_test.go
+++ b/regex/rstring/string_test.go
@@ -104,13 +104,27 @@ func TestContainsSpecialChars(t *testing.T) {
 }
 
 func TestRemoveLineBreaks(t *testing.T) {
-	input := "One\r,\r\ntwo\u0085 three\u2028!\u2029'"
-	result := "One,two three!'"
-	output := rstring.RemoveLineBreaks(input)
-	diff := reflect.DeepEqual(result, output)
+	type test struct {
+		name   string
+		input  string
+		output string
+	}
 
-	if !diff {
-		t.Errorf("RemoveLineBreaks(%s) Failed: expected %s, actual %s",
-			input, result, output)
+	tests := []test{
+		{name: "MultipleLineBreaks", input: "One\r,\r\ntwo\u0085 three\u2028!\u2029'", output: "One,two three!'"},
+		{name: "WindowsLineBreak", input: "Win\r\n", output: "Win"},
+		{name: "MacLineBreak", input: "Mac\r", output: "Mac"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			result := rstring.RemoveLineBreaks(tc.input)
+			diff := reflect.DeepEqual(result, tc.output)
+			if !diff {
+				t.Errorf("RemoveLineBreaks(%s) Failed: expected %s, actual %s",
+					tc.input, tc.output, result)
+			}
+		})
 	}
 }


### PR DESCRIPTION
RemoveLineBreaks removes all line breaks from a string using a regex.
As per https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#lineending,
Any Unicode linebreak sequence, is equivalent to \u000D\u000A|[\u000A\u000B\u000C\u000D\u0085\u2028\u2029] .